### PR TITLE
fix error introducing nonexistent phone T_h

### DIFF
--- a/dictionaries/ice_pron_dict_north_clear.csv
+++ b/dictionaries/ice_pron_dict_north_clear.csv
@@ -28594,7 +28594,7 @@ netverkefni	n E: t_h v E r_0 k E p n I
 netverslun	n E: t_h v E r_0 s t l Y n
 network	n E t v 9 r_0 k
 netútgáfu	n E: t_h u t k au v Y
-netþjón	n E: t T_h j ou n
+netþjón	n E: t_h T j ou n
 netþjónn	n E: t_h T j ou t n_0
 neuer	n Oi E r
 neutral	n j u: t_h r a l

--- a/dictionaries/ice_pron_dict_northeast_clear.csv
+++ b/dictionaries/ice_pron_dict_northeast_clear.csv
@@ -28594,7 +28594,7 @@ netverkefni	n E: t_h v E r_0 k E p n I
 netverslun	n E: t_h v E r_0 s t l Y n
 network	n E t v 9 r_0 k
 netútgáfu	n E: t_h u t k au v Y
-netþjón	n E: t T_h j ou n
+netþjón	n E: t_h T j ou n
 netþjónn	n E: t_h T j ou t n_0
 neuer	n Oi E r
 neutral	n j u: t_h r a l


### PR DESCRIPTION
One entry in the dictionary erroneously introduces the nonexistent phoneme T_h, which would theoretically be an aspirated unvoiced dental fricative.

This is however a transcription mistake since inspecting the entry reveals that the previous phone should be aspirated instead.

This PR removes all instances of this erroneous entry.